### PR TITLE
Fix insecure entity NBT usage

### DIFF
--- a/src/main/java/cn/davidma/tinymobfarm/common/tileentity/TileEntityMobFarm.java
+++ b/src/main/java/cn/davidma/tinymobfarm/common/tileentity/TileEntityMobFarm.java
@@ -89,8 +89,11 @@ public class TileEntityMobFarm extends TileEntity implements ITickableTileEntity
 	
 	private void generateDrops() {
 		ItemStack lasso = this.getLasso();
-		String lootTableLocation = NBTHelper.getBaseTag(lasso).getString(NBTHelper.MOB_LOOTTABLE_LOCATION);
+		CompoundNBT nbt = NBTHelper.getBaseTag(lasso);
+		String lootTableLocation = nbt.getString(NBTHelper.MOB_LOOTTABLE_LOCATION);
 		if (lootTableLocation.isEmpty()) return;
+		CompoundNBT mobData = nbt.getCompound(NBTHelper.MOB_DATA);
+		if (EntityType.readEntityType(mobData).filter(EntityHelper::isMobBlacklisted).isPresent()) return;
 		
 		List<ItemStack> drops = EntityHelper.generateLoot(new ResourceLocation(lootTableLocation), this.world, EnchantmentHelper.getEnchantmentLevel(Enchantments.LOOTING, lasso));
 		for (Direction facing: Direction.values()) {

--- a/src/main/java/cn/davidma/tinymobfarm/core/util/EntityHelper.java
+++ b/src/main/java/cn/davidma/tinymobfarm/core/util/EntityHelper.java
@@ -18,13 +18,13 @@ import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
 public class EntityHelper {
 	
-	public static String getRegistryName(LivingEntity LivingEntity) {
-		EntityType<?> entityType = LivingEntity.getType();
-		return entityType.getRegistryName().toString();
+	public static boolean isMobBlacklisted(LivingEntity livingEntity) {
+		EntityType<?> entityType = livingEntity.getType();
+		return isMobBlacklisted(entityType);
 	}
-	
-	public static boolean isMobBlacklisted(LivingEntity LivingEntity) {
-		String mobName = getRegistryName(LivingEntity);
+
+	public static boolean isMobBlacklisted(EntityType<?> entityType) {
+		String mobName = entityType.getRegistryName().toString();
 		for (String i: Config.MOB_BLACKLIST) {
 			if (mobName.equalsIgnoreCase(i)) {
 				return true;


### PR DESCRIPTION
Currently, the [Lasso release](https://github.com/davidmaamoaix/TinyMobFarm/blob/8621ce096561fef81f721041fb40f43e1d1da801/src/main/java/cn/davidma/tinymobfarm/common/item/ItemLasso.java#L105-L136) does not respect blacklist or consider op only NBT security specified by captured entities. This can be exploited by players with access to creative mode to execute arbitrary command block permission commands via a specially crafting item.

This PR resolves the issue by introducing a blacklist check, ensuring `MobEntity` assignability, and adding the op only NBT requirement. As well, a blacklist guard is added to loot generation.